### PR TITLE
Fix incorrect nullish coercing documentation

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -22,7 +22,7 @@ This rule will not work as expected if [`strictNullChecks`](https://www.typescri
 
 ### `ignoreTernaryTests`
 
-Setting this option to `true` (the default) will cause the rule to ignore any ternary expressions that could be simplified by using the nullish coalescing operator.
+Setting this option to `true` will cause the rule to ignore any ternary expressions that could be simplified by using the nullish coalescing operator.
 
 Incorrect code for `ignoreTernaryTests: false`, and correct code for `ignoreTernaryTests: true`:
 
@@ -62,7 +62,7 @@ foo ?? 'a string';
 
 ### `ignoreConditionalTests`
 
-Setting this option to `true` (the default) will cause the rule to ignore any cases that are located within a conditional test.
+Setting this option to `true` will cause the rule to ignore any cases that are located within a conditional test.
 
 Generally expressions within conditional tests intentionally use the falsy fallthrough behavior of the logical or operator, meaning that fixing the operator to the nullish coalesce operator could cause bugs.
 
@@ -104,7 +104,7 @@ a ?? b ? true : false;
 
 ### `ignoreMixedLogicalExpressions`
 
-Setting this option to `true` (the default) will cause the rule to ignore any logical or expressions that are part of a mixed logical expression (with `&&`).
+Setting this option to `true` will cause the rule to ignore any logical or expressions that are part of a mixed logical expression (with `&&`).
 
 Generally expressions within mixed logical expressions intentionally use the falsy fallthrough behavior of the logical or operator, meaning that fixing the operator to the nullish coalesce operator could cause bugs.
 


### PR DESCRIPTION
This is saying that `true` is default when it's `false` that is default